### PR TITLE
Create test helpers and reset mocks before each test

### DIFF
--- a/tests/ecr.test.ts
+++ b/tests/ecr.test.ts
@@ -5,20 +5,17 @@ import {
   ECRClient,
   PutLifecyclePolicyCommand,
 } from '@aws-sdk/client-ecr'
-import { runForECR } from '../src/ecr'
-
-const ecrMock = mockClient(ECRClient)
+import { runForECR } from '../src/ecr';
+import { mockCreateResponse, mockDescribeResponse } from './helpers';
 
 describe('Create an ECR repository if not exist', () => {
+  const ecrMock = mockClient(ECRClient);
+  beforeEach(() => ecrMock.reset());
+
   test('returns the existing repository', async () => {
-    ecrMock.on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] }).resolves({
-      repositories: [
-        {
-          repositoryName: 'foobar',
-          repositoryUri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar',
-        },
-      ],
-    })
+    ecrMock
+    .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
+    .resolves(mockDescribeResponse('ap-northeast-1'))
 
     const output = await runForECR({ repository: 'foobar' })
     expect(output.repositoryUri).toEqual('123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar')
@@ -28,14 +25,12 @@ describe('Create an ECR repository if not exist', () => {
     ecrMock
       .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
       .rejects({ name: 'RepositoryNotFoundException' })
-    ecrMock.on(CreateRepositoryCommand, { repositoryName: 'foobar' }).resolves({
-      repository: {
-        repositoryName: 'foobar',
-        repositoryUri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar',
-      },
-    })
+    ecrMock
+      .on(CreateRepositoryCommand, { repositoryName: 'foobar' })
+      .resolves(mockCreateResponse('ap-northeast-1'))
 
     const output = await runForECR({ repository: 'foobar' })
+
     expect(output.repositoryUri).toEqual('123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar')
   })
 
@@ -56,41 +51,31 @@ describe('Create an ECR repository if not exist', () => {
 })
 
 describe('Put a lifecycle policy', () => {
+  const ecrMock = mockClient(ECRClient);
+  beforeEach(() => ecrMock.reset());
+
   test('success', async () => {
-    ecrMock.on(DescribeRepositoriesCommand).resolves({
-      repositories: [
-        {
-          repositoryName: 'foobar',
-          repositoryUri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar',
-        },
-      ],
-    })
+    ecrMock
+    .on(DescribeRepositoriesCommand)
+    .resolves(mockDescribeResponse('ap-northeast-1'))
     ecrMock
       .on(PutLifecyclePolicyCommand, {
         repositoryName: 'foobar',
         lifecyclePolicyText: `{ "rules": [{ "description": "dummy" }] }`,
       })
-      .resolves({
-        repositoryName: 'foobar',
-      })
+      .resolves({ repositoryName: 'foobar' })
 
     const output = await runForECR({
       repository: 'foobar',
       lifecyclePolicy: `${__dirname}/fixtures/lifecycle-policy.json`,
     })
-    expect(output.repositoryUri).toBe('123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar')
+
+    expect(output.repositoryUri).toEqual('123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar')
   })
 
   test('file not exist', async () => {
-    ecrMock.on(DescribeRepositoriesCommand).resolves({
-      repositories: [
-        {
-          repositoryName: 'foobar',
-          repositoryUri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar',
-        },
-      ],
-    })
+    ecrMock.on(DescribeRepositoriesCommand).resolves(mockDescribeResponse('ap-northeast-1'))
 
     await expect(runForECR({ repository: 'foobar', lifecyclePolicy: 'wrong-path' })).rejects.toThrow()
   })
-})
+});

--- a/tests/ecr.test.ts
+++ b/tests/ecr.test.ts
@@ -5,17 +5,17 @@ import {
   ECRClient,
   PutLifecyclePolicyCommand,
 } from '@aws-sdk/client-ecr'
-import { runForECR } from '../src/ecr';
-import { mockCreateResponse, mockDescribeResponse } from './helpers';
+import { runForECR } from '../src/ecr'
+import { mockCreateResponse, mockDescribeResponse } from './helpers'
 
 describe('Create an ECR repository if not exist', () => {
-  const ecrMock = mockClient(ECRClient);
-  beforeEach(() => ecrMock.reset());
+  const ecrMock = mockClient(ECRClient)
+  beforeEach(() => ecrMock.reset())
 
   test('returns the existing repository', async () => {
     ecrMock
-    .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
-    .resolves(mockDescribeResponse('ap-northeast-1'))
+      .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
+      .resolves(mockDescribeResponse('ap-northeast-1'))
 
     const output = await runForECR({ repository: 'foobar' })
     expect(output.repositoryUri).toEqual('123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar')
@@ -25,9 +25,7 @@ describe('Create an ECR repository if not exist', () => {
     ecrMock
       .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
       .rejects({ name: 'RepositoryNotFoundException' })
-    ecrMock
-      .on(CreateRepositoryCommand, { repositoryName: 'foobar' })
-      .resolves(mockCreateResponse('ap-northeast-1'))
+    ecrMock.on(CreateRepositoryCommand, { repositoryName: 'foobar' }).resolves(mockCreateResponse('ap-northeast-1'))
 
     const output = await runForECR({ repository: 'foobar' })
 
@@ -51,13 +49,11 @@ describe('Create an ECR repository if not exist', () => {
 })
 
 describe('Put a lifecycle policy', () => {
-  const ecrMock = mockClient(ECRClient);
-  beforeEach(() => ecrMock.reset());
+  const ecrMock = mockClient(ECRClient)
+  beforeEach(() => ecrMock.reset())
 
   test('success', async () => {
-    ecrMock
-    .on(DescribeRepositoriesCommand)
-    .resolves(mockDescribeResponse('ap-northeast-1'))
+    ecrMock.on(DescribeRepositoriesCommand).resolves(mockDescribeResponse('ap-northeast-1'))
     ecrMock
       .on(PutLifecyclePolicyCommand, {
         repositoryName: 'foobar',
@@ -78,4 +74,4 @@ describe('Put a lifecycle policy', () => {
 
     await expect(runForECR({ repository: 'foobar', lifecyclePolicy: 'wrong-path' })).rejects.toThrow()
   })
-});
+})

--- a/tests/ecr_public.test.ts
+++ b/tests/ecr_public.test.ts
@@ -1,17 +1,14 @@
 import { mockClient } from 'aws-sdk-client-mock'
 import { CreateRepositoryCommand, DescribeRepositoriesCommand, ECRPUBLICClient } from '@aws-sdk/client-ecr-public'
 import { runForECRPublic } from '../src/ecr_public'
-import { mockCreateResponse, mockDescribeResponse } from './helpers';
-
+import { mockCreateResponse, mockDescribeResponse } from './helpers'
 
 describe('Create an ECR repository if not exist', () => {
-  const ecrMock = mockClient(ECRPUBLICClient);
-  beforeEach(() => ecrMock.reset());
+  const ecrMock = mockClient(ECRPUBLICClient)
+  beforeEach(() => ecrMock.reset())
 
   test('returns the existing repository', async () => {
-    ecrMock
-      .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
-      .resolves(mockDescribeResponse('', true))
+    ecrMock.on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] }).resolves(mockDescribeResponse('', true))
 
     const repository = await runForECRPublic({ repository: 'foobar' })
     expect(repository.repositoryUri).toEqual('public.ecr.aws/12345678/foobar')
@@ -21,9 +18,7 @@ describe('Create an ECR repository if not exist', () => {
     ecrMock
       .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
       .rejects({ name: 'RepositoryNotFoundException' })
-    ecrMock
-      .on(CreateRepositoryCommand, { repositoryName: 'foobar' })
-      .resolves(mockCreateResponse('', true))
+    ecrMock.on(CreateRepositoryCommand, { repositoryName: 'foobar' }).resolves(mockCreateResponse('', true))
 
     const repository = await runForECRPublic({ repository: 'foobar' })
 

--- a/tests/ecr_public.test.ts
+++ b/tests/ecr_public.test.ts
@@ -1,19 +1,17 @@
 import { mockClient } from 'aws-sdk-client-mock'
 import { CreateRepositoryCommand, DescribeRepositoriesCommand, ECRPUBLICClient } from '@aws-sdk/client-ecr-public'
 import { runForECRPublic } from '../src/ecr_public'
+import { mockCreateResponse, mockDescribeResponse } from './helpers';
 
-const ecrMock = mockClient(ECRPUBLICClient)
 
 describe('Create an ECR repository if not exist', () => {
+  const ecrMock = mockClient(ECRPUBLICClient);
+  beforeEach(() => ecrMock.reset());
+
   test('returns the existing repository', async () => {
-    ecrMock.on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] }).resolves({
-      repositories: [
-        {
-          repositoryName: 'foobar',
-          repositoryUri: 'public.ecr.aws/12345678/foobar',
-        },
-      ],
-    })
+    ecrMock
+      .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
+      .resolves(mockDescribeResponse('', true))
 
     const repository = await runForECRPublic({ repository: 'foobar' })
     expect(repository.repositoryUri).toEqual('public.ecr.aws/12345678/foobar')
@@ -23,14 +21,12 @@ describe('Create an ECR repository if not exist', () => {
     ecrMock
       .on(DescribeRepositoriesCommand, { repositoryNames: ['foobar'] })
       .rejects({ name: 'RepositoryNotFoundException' })
-    ecrMock.on(CreateRepositoryCommand, { repositoryName: 'foobar' }).resolves({
-      repository: {
-        repositoryName: 'foobar',
-        repositoryUri: 'public.ecr.aws/12345678/foobar',
-      },
-    })
+    ecrMock
+      .on(CreateRepositoryCommand, { repositoryName: 'foobar' })
+      .resolves(mockCreateResponse('', true))
 
     const repository = await runForECRPublic({ repository: 'foobar' })
+
     expect(repository.repositoryUri).toEqual('public.ecr.aws/12345678/foobar')
   })
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,23 @@
+import { CreateRepositoryResponse, DescribeRepositoriesResponse } from "@aws-sdk/client-ecr";
+
+// Helper to create a DescribeRepositoriesResponse
+export const mockDescribeResponse = (region = 'ap-northeast-1', isPublic = false): DescribeRepositoriesResponse => ({
+  repositories: [
+    {
+      repositoryName: 'foobar',
+      repositoryUri: isPublic
+        ? 'public.ecr.aws/12345678/foobar'
+        : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`
+    },
+  ],
+});
+
+// Helper to create a CreateRepositoryResponse
+export const mockCreateResponse = (region = 'ap-northeast-1', isPublic = false): CreateRepositoryResponse => ({
+  repository: {
+    repositoryName: 'foobar',
+    repositoryUri: isPublic
+      ? 'public.ecr.aws/12345678/foobar'
+      : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`
+  },
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { CreateRepositoryResponse, DescribeRepositoriesResponse } from "@aws-sdk/client-ecr";
+import { CreateRepositoryResponse, DescribeRepositoriesResponse } from '@aws-sdk/client-ecr'
 
 // Helper to create a DescribeRepositoriesResponse
 export const mockDescribeResponse = (region = 'ap-northeast-1', isPublic = false): DescribeRepositoriesResponse => ({
@@ -7,17 +7,15 @@ export const mockDescribeResponse = (region = 'ap-northeast-1', isPublic = false
       repositoryName: 'foobar',
       repositoryUri: isPublic
         ? 'public.ecr.aws/12345678/foobar'
-        : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`
+        : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`,
     },
   ],
-});
+})
 
 // Helper to create a CreateRepositoryResponse
 export const mockCreateResponse = (region = 'ap-northeast-1', isPublic = false): CreateRepositoryResponse => ({
   repository: {
     repositoryName: 'foobar',
-    repositoryUri: isPublic
-      ? 'public.ecr.aws/12345678/foobar'
-      : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`
+    repositoryUri: isPublic ? 'public.ecr.aws/12345678/foobar' : `123456789012.dkr.ecr.${region}.amazonaws.com/foobar`,
   },
-});
+})


### PR DESCRIPTION
# Summary

Whilst working on adding region support for #883 I found I was making a lot of changes to existing tests.

To reduce the size of that upcoming PR I thought I should split out this smaller change to:
- add test helpers for mock responses.
- reset the mocked client before each test as this was causing flaky tests
- have a consistent indent style of the `.on()` and `.resolves()` because why not

## Notes

I currently just import the `helpers.ts` file in the test files. However, we could use jest helpers and create a `tsconfig.test.json`, etc. if we wanted to go that way. Seemed to big a change for a first contribution. See https://stackoverflow.com/a/52910794.
