### PR TITLE
Allow Repos to be immutable, and be tagged

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,13 @@ inputs:
   repository-policy:
     required: false
     description: path to repository policy file of the repository (optional)
+  immutable:
+    required: false
+    description: set true to set immutable tags
+    default: 'false'
+  tags:
+    required: false
+    description: metadata that you apply to the repository to help you categorize and organize them
 
 outputs:
   repository-uri:

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ const main = async (): Promise<void> => {
   const outputs = await run({
     public: core.getBooleanInput('public', { required: true }),
     repository: core.getInput('repository', { required: true }),
+    immutable: core.getInput('immutable') === 'true' ? true : undefined,
+    tags: core.getInput('tags') || undefined,
     lifecyclePolicy: core.getInput('lifecycle-policy') || undefined,
     repositoryPolicy: core.getInput('repository-policy') || undefined,
   })

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,6 +4,8 @@ import { runForECRPublic } from './ecr_public.js'
 type Inputs = {
   public: boolean
   repository: string
+  immutable: boolean | undefined
+  tags: string | undefined
   lifecyclePolicy: string | undefined
   repositoryPolicy: string | undefined
 }

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -25,6 +25,8 @@ test('ecr', async () => {
     lifecyclePolicy: `${__dirname}/fixtures/lifecycle-policy.json`,
     repositoryPolicy: `${__dirname}/fixtures/repository-policy.json`,
     public: false,
+    immutable: true,
+    tags: 'foo=bar,baz=qux',
   })
   expect(outputs).toStrictEqual({ repositoryUri: '123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foobar' })
 })
@@ -43,6 +45,8 @@ test('ecr public', async () => {
     lifecyclePolicy: undefined,
     repositoryPolicy: `${__dirname}/fixtures/repository-policy.json`,
     public: true,
+    immutable: true,
+    tags: 'foo=bar,baz=qux',
   })
   expect(outputs).toStrictEqual({ repositoryUri: 'public.ecr.aws/12345678/foobar' })
 })


### PR DESCRIPTION
I have a requirement that ECR repos are automatically configured to be immutable, and have tags attached to them. This PR should address those requirements for private repositories.